### PR TITLE
Revert "Bump bootstrap from 4.6.2 to 5.0.1 in /frontend (#66)"

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,7 +17,7 @@
     "@types/react-modal": "^3.1.2",
     "axios": "^1.7.4",
     "babel-plugin-macros": "^3.1.0",
-    "bootstrap": "^5.0.1",
+    "bootstrap": "^4.1.0",
     "classnames": "^2.3.2",
     "filesize": "^10.0.7",
     "katex": "^0.16.10",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -3391,10 +3391,10 @@ boolbase@^1.0.0, boolbase@~1.0.0:
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
   integrity sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==
 
-bootstrap@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-5.0.1.tgz#e7939d599119dc818a90478a2a299bdaff037e09"
-  integrity sha512-Fl79+wsLOZKoiU345KeEaWD0ik8WKRI5zm0YSPj2oF1Qr+BO7z0fco6GbUtqjoG1h4VI89PeKJnMsMMVQdKKTw==
+bootstrap@^4.1.0:
+  version "4.6.2"
+  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-4.6.2.tgz#8e0cd61611728a5bf65a3a2b8d6ff6c77d5d7479"
+  integrity sha512-51Bbp/Uxr9aTuy6ca/8FbFloBUJZLHwnhTcnjIeRn2suQWsWzcuJhGjKDB5eppVte/8oCdOL3VuwxvZDUggwGQ==
 
 bplist-parser@^0.2.0:
   version "0.2.0"


### PR DESCRIPTION
This reverts commit 261b35908f567732169504260e46dfbcd6436fb3.